### PR TITLE
Fix typo of `StorageOptions` import

### DIFF
--- a/pages/file-storage.mdx
+++ b/pages/file-storage.mdx
@@ -20,7 +20,7 @@ Below we have explained the different `disk` configurations available which you 
 
 ```ts filename="config/filesystem.ts"
 import { fromIni } from '@aws-sdk/credential-providers';
-import { StorageOption, registerAs } from '@intentjs/core';
+import { StorageOptions, registerAs } from '@intentjs/core';
 
 export default registerAs(
   'filesystem',


### PR DESCRIPTION
Fixes the import of `StorageOptions` which is mistyped as `StorageOption`