### PR TITLE
Fix: Correct directory name in setup documentation

### DIFF
--- a/docs/first-project.md
+++ b/docs/first-project.md
@@ -24,7 +24,7 @@ npm i -g @intentjs/cli
 intent new my-project
 ```
 
-Once this command has ran, move to the directory `new-sample-app` and open it inside your fav code editor.
+Once this command has ran, move to the directory `my-project` and open it inside your fav code editor.
 
 You can read more about the directory structure [here](https://tryintent.com/docs/directory-structure).
 


### PR DESCRIPTION
This pull request addresses a minor issue in the documentation where the directory name mentioned in the setup instructions was incorrect.

Changes Made:
Replaced _new-sample-app_ with the correct directory name _**my-project**_ in the setup instructions.

Reason for Change:
The command `intent new my-project` creates a project directory named `my-project`. To ensure clarity and avoid confusion for users, the directory name in the documentation should match the output of the command.